### PR TITLE
adding sso label

### DIFF
--- a/sso.mdx
+++ b/sso.mdx
@@ -1,3 +1,8 @@
+---
+title: 'SSO'
+description: 'Enable seamless and secure access to multiple applications with Single Sign-On (SSO) using the SAML protocol, enhancing user experience and security.'
+---
+
 # Single Sign-On (SSO)
 
 ## Overview


### PR DESCRIPTION
Without title, it's showing it as Sso. It should be SSO

Should this be part of Integrations? 

<img width="713" alt="image" src="https://github.com/user-attachments/assets/3d933eac-bede-4baf-bcb1-b35471d60cc7" />
