### PR TITLE
Adding example for private deployment

### DIFF
--- a/azure_devops.mdx
+++ b/azure_devops.mdx
@@ -65,7 +65,7 @@ To enable scans for each pull request, configure a webhook. Ensure you possess t
     </Frame>
   </Step>
   <Step>
-    In the Settings section, input the URL as https://www.corgea.app/azure_webhook/ or {YOUR_CORGEA_SERVER}/azure_webhook/ for private deployments.
+    In the Settings section, input the URL as https://www.corgea.app/azure_webhook/ or `https://your_instance.corgea.app/azure_webhook/` for private deployments.
     <Frame>
       <img src="/images/azure-webhook-fill-in-url.png" style={{ borderRadius: '0.5rem' }} alt="Webhook URL" />
     </Frame>

--- a/sso.mdx
+++ b/sso.mdx
@@ -34,7 +34,9 @@ To access the SSO by SAML feature, you must provide either a SAML metadata link 
 - **Application Username**: Email
 - **Update Application Username On**: Create and update
 
-For the "Attribute Statement (optional)" section, use the following mappings:
+Note: Replace `https://www.corgea.app` with `https://your_instance.corgea.app` if you are on private deployment.
+
+2. For the "Attribute Statement (optional)" section, use the following mappings:
 
 - **Name** -> **Value**
   - email -> user.email


### PR DESCRIPTION
{YOUR_CORGEA_SERVER} was considered as templating on mintlify so it wasn't showing up
adding private domain for SSO and Azure case that was bit confusing to customers. 